### PR TITLE
Drop the `syn` upgrade

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -40,8 +40,6 @@ else
     else
         CARGO=cargo
     fi
-    echo "fixing syn dep"
-    cargo update 'syn@2.0'
     echo "$CARGO build --release $build_args" >&2
     $CARGO build --release $build_args
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     sha256: bb0fa9591b4495ff6728be13d80a3c8db792cc3bddba107cd183a99ab7db8b48  # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:   # [not osx or not arm64]
   build:   # [not osx or not arm64]


### PR DESCRIPTION
Quick PR to try dropping the `syn` upgrade that wasn't actually needed to fix #132.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
