### PR TITLE
Re-enable linux-aarch64 builds (Travis edition)

### DIFF
--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,24 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+libprotobuf:
+- 5.27.5
+rust_compiler:
+- rust
+rust_compiler_version:
+- 1.82.0
+target_platform:
+- linux-aarch64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: shell
+
+
+
+jobs:
+  include:
+    - env: CONFIG=linux_aarch64_ UPLOAD_PACKAGES=True PLATFORM=linux-aarch64 DOCKER_IMAGE=quay.io/condaforge/linux-anvil-aarch64:alma9
+      os: linux
+      arch: arm64
+      dist: focal
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+  - export flow_run_id="travis_$TRAVIS_JOB_ID"
+  - export sha="$TRAVIS_COMMIT"
+  - export remote_url="https://github.com/$TRAVIS_REPO_SLUG"
+  - export FEEDSTOCK_NAME=$(basename ${TRAVIS_REPO_SLUG})
+  - if [[ "${TRAVIS_PULL_REQUEST:-}" == "false" ]]; then export IS_PR_BUILD="False"; else export IS_PR_BUILD="True"; fi
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then CONDA_FORGE_DOCKER_RUN_ARGS="--network=host --security-opt=seccomp=unconfined" travis_wait 60 ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://app.travis-ci.com/conda-forge/deno-feedstock">
+        <img alt="linux" src="https://img.shields.io/travis/com/conda-forge/deno-feedstock/main.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -35,6 +42,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/deno-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/deno-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,8 +5,10 @@ azure:
       MINIFORGE_HOME: C:\Miniforge
       SET_PAGEFILE: "True"
 build_platform:
-  # linux_aarch64: linux_64
+  linux_aarch64: linux_aarch64
   osx_arm64: osx_64
+provider:
+  linux_aarch64: default
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,7 +41,7 @@ else
         CARGO=cargo
     fi
     echo "$CARGO build --release $build_args" >&2
-    $CARGO build --release -v $build_args
+    $CARGO build --release $build_args
 
     mkdir -p $PREFIX/bin
     OUTPUT_EXE=$(find target -name deno | tail -n 1)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,7 +41,7 @@ else
         CARGO=cargo
     fi
     echo "$CARGO build --release $build_args" >&2
-    $CARGO build --release $build_args
+    $CARGO build --release $build_args -p deno
 
     mkdir -p $PREFIX/bin
     OUTPUT_EXE=$(find target -name deno | tail -n 1)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,16 @@ source:
     sha256: f48758771a456db3fabdf8665a4576f6d9dc24ff6d75a82f120d093b0307efd1  # [not osx or not arm64]
     patches:   # [win]
       - 01-fix-libffi-msvc.patch     # [win]
-  - url: https://github.com/rust-lang/cargo/archive/refs/tags/0.75.0.tar.gz  # [linux and aarch64]
-    sha256: d6b9512bca4b4d692a242188bfe83e1b696c44903007b7b48a56b287d01c063b  # [linux and aarch64]
-    folder: cargo-cross  # [linux and aarch64]
-    patches:   # [linux and aarch64]
-      - cargo-cross-build.patch                                               # [linux and aarch64]
+  # - url: https://github.com/rust-lang/cargo/archive/refs/tags/0.75.0.tar.gz  # [linux and aarch64]
+  #   sha256: d6b9512bca4b4d692a242188bfe83e1b696c44903007b7b48a56b287d01c063b  # [linux and aarch64]
+  #   folder: cargo-cross  # [linux and aarch64]
+  #   patches:   # [linux and aarch64]
+  #     - cargo-cross-build.patch                                               # [linux and aarch64]
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-apple-darwin.zip  # [osx and arm64]
     sha256: 65efe137ee28846427ae7b6c5135439744065ad59ccb3c8cd19e69af066e2db0  # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:   # [not osx or not arm64]
   build:   # [not osx or not arm64]
@@ -34,13 +34,13 @@ requirements:   # [not osx or not arm64]
     # libprotobuf is on build, not host, since we only need protoc
     - libprotobuf  # [not osx or not arm64]
     # on linux cross-builds, we need additional build deps for patched cargo
-    - zlib         # [linux and aarch64]
+    # - zlib         # [linux and aarch64]
     - libclang     # [linux and x86_64]
     - llvmdev      # [linux and x86_64]
   # cross-builds also need host libgcc to run the cross-built files
-  host:   # [linux]
-    - libgcc    # [linux and aarch64]
-  run:   # [osx and x86_64]
+  # host:   # [linux]
+  #  - libgcc    # [linux and aarch64]
+  # run:   # [osx and x86_64]
 
 test:
   files:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This tries using Travis again to enable AARCH64 builds — we'll see if that's working.