### PR TITLE
Re-enable linux-aarch64 (non-snapshotting version)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libprotobuf:
-- 5.27.5
+- 5.28.2
 rust_compiler:
 - rust
 rust_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,11 +1,19 @@
 c_compiler:
-- vs2019
+- clang
+c_compiler_version:
+- '18'
 c_stdlib:
-- vs
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 libprotobuf:
 - 5.28.2
 rust_compiler:
@@ -13,4 +21,6 @@ rust_compiler:
 rust_compiler_version:
 - 1.82.0
 target_platform:
-- win-64
+- linux-aarch64
+zlib:
+- '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 libprotobuf:
-- 5.27.5
+- 5.28.2
 macos_machine:
 - x86_64-apple-darwin13.4.0
 rust_compiler:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/deno-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,7 @@ azure:
       MINIFORGE_HOME: C:\Miniforge
       SET_PAGEFILE: "True"
 build_platform:
-  # linux_aarch64: linux_64
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'

--- a/recipe/01-fix-libffi-msvc.patch
+++ b/recipe/01-fix-libffi-msvc.patch
@@ -1,6 +1,6 @@
-fix libffi builds on MSVC
 
-From: Michael Ekstrand <md@ekstrandom.net>
+
+From: Michael Ekstrand <mdekstrand@drexel.edu>
 
 
 ---
@@ -8,11 +8,11 @@ From: Michael Ekstrand <md@ekstrandom.net>
  1 file changed, 3 insertions(+)
 
 diff --git a/Cargo.toml b/Cargo.toml
-index d811d44b5..4d6c61e32 100644
+index 712bdae8b..3003db59f 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -228,6 +228,9 @@ winapi = "=0.3.9"
- windows-sys = { version = "0.52.0", features = ["Win32_Foundation", "Win32_Media", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_WindowsProgramming", "Wdk", "Wdk_System", "Wdk_System_SystemInformation", "Win32_Security", "Win32_System_Pipes", "Wdk_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Kernel"] }
+@@ -243,6 +243,9 @@ winapi = "=0.3.9"
+ windows-sys = { version = "0.59.0", features = ["Win32_Foundation", "Win32_Media", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_WindowsProgramming", "Wdk", "Wdk_System", "Wdk_System_SystemInformation", "Win32_Security", "Win32_System_Pipes", "Wdk_Storage_FileSystem", "Win32_System_Registry", "Win32_System_Kernel", "Win32_System_Threading", "Win32_UI", "Win32_UI_Shell"] }
  winres = "=0.1.12"
  
 +[patch.crates-io]

--- a/recipe/02-disable-snapshot.patch
+++ b/recipe/02-disable-snapshot.patch
@@ -1,0 +1,63 @@
+Disable snapshotting in default build
+
+From: Michael Ekstrand <mdekstrand@drexel.edu>
+
+
+---
+ Cargo.lock     |    3 +--
+ cli/Cargo.toml |    4 ++--
+ cli/build.rs   |   12 ------------
+ 3 files changed, 3 insertions(+), 16 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index d82040854..31293c264 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -4556,8 +4556,7 @@ dependencies = [
+ [[package]]
+ name = "libffi-sys"
+ version = "2.3.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
++source = "git+https://github.com/tov/libffi-rs?branch=master#d0704d634b6f3ffef5b6fc7e07fe965a1cff5c7b"
+ dependencies = [
+  "cc",
+ ]
+diff --git a/cli/Cargo.toml b/cli/Cargo.toml
+index cf76dfe69..eb42b2b97 100644
+--- a/cli/Cargo.toml
++++ b/cli/Cargo.toml
+@@ -54,8 +54,8 @@ hmr = ["deno_runtime/hmr"]
+ __vendored_zlib_ng = ["flate2/zlib-ng-compat", "libz-sys/zlib-ng"]
+ 
+ [build-dependencies]
+-deno_runtime = { workspace = true, features = ["include_js_files_for_snapshotting", "only_snapshotted_js_sources"] }
+-deno_core = { workspace = true, features = ["include_js_files_for_snapshotting"] }
++deno_runtime = { workspace = true }
++deno_core = { workspace = true }
+ lazy-regex.workspace = true
+ serde.workspace = true
+ serde_json.workspace = true
+diff --git a/cli/build.rs b/cli/build.rs
+index 3d9866128..4ac8d9c8f 100644
+--- a/cli/build.rs
++++ b/cli/build.rs
+@@ -418,18 +418,6 @@ fn main() {
+     println!("cargo:rustc-link-arg-bin=denort=delayimp.lib");
+   }
+ 
+-  let c = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+-  let o = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+-
+-  let compiler_snapshot_path = o.join("COMPILER_SNAPSHOT.bin");
+-  ts::create_compiler_snapshot(compiler_snapshot_path, &c);
+-
+-  #[cfg(not(feature = "hmr"))]
+-  {
+-    let cli_snapshot_path = o.join("CLI_SNAPSHOT.bin");
+-    create_cli_snapshot(cli_snapshot_path);
+-  }
+-
+   #[cfg(target_os = "windows")]
+   {
+     let mut res = winres::WindowsResource::new();

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,7 +41,7 @@ else
         CARGO=cargo
     fi
     echo "$CARGO build --release $build_args" >&2
-    $CARGO build --release -v $build_args
+    $CARGO build --release -v $build_args -p deno-cli
 
     mkdir -p $PREFIX/bin
     OUTPUT_EXE=$(find target -name deno | tail -n 1)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,7 +41,7 @@ else
         CARGO=cargo
     fi
     echo "$CARGO build --release $build_args" >&2
-    $CARGO build --release -v $build_args -p deno-cli
+    $CARGO build --release -v $build_args -p deno
 
     mkdir -p $PREFIX/bin
     OUTPUT_EXE=$(find target -name deno | tail -n 1)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,24 +21,15 @@ else
     # turn down LTO for all builds, it takes forever
     export CARGO_PROFILE_RELEASE_LTO=thin
 
+    CARGO=cargo
     build_args=
     if [[ "$CONDA_TOOLCHAIN_BUILD" != "$CONDA_TOOLCHAIN_HOST" ]]; then
         echo "Building for target $CARGO_BUILD_TARGET" >&2
-        echo "Building patched cargo" >&2
-        (cd cargo-cross && cargo build --release --features all-static --target x86_64-unknown-linux-gnu)
-        CARGO="$PWD/cargo-cross/target/x86_64-unknown-linux-gnu/release/cargo"
-
+        
         # we know what we're doing lol
         export DENO_SKIP_CROSS_BUILD_CHECK=1
         # this var screws up libffi builds, we need both build & host builds
         unset host_alias
-
-        # set up the cross-build things
-        export CARGO_CROSS_BUILD_CRATES=deno_runtime:deno
-        export CARGO_CROSS_BUILD_RS=deno_runtime/build.rs:deno/build.rs
-        export CARGO_CROSS_BUILD_RUN="$RECIPE_DIR/cross-run.sh"
-    else
-        CARGO=cargo
     fi
     echo "$CARGO build --release $build_args" >&2
     $CARGO build --release -v $build_args -p deno

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno_src.tar.gz  # [not osx or not arm64]
     sha256: f48758771a456db3fabdf8665a4576f6d9dc24ff6d75a82f120d093b0307efd1  # [not osx or not arm64]
-    patches:   # [win]
+    patches:
       - 01-fix-libffi-msvc.patch     # [win]
       - 02-disable-snapshot.patch    # [linux and aarch64]
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-apple-darwin.zip  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno_src.tar.gz  # [not osx or not arm64]
     sha256: f48758771a456db3fabdf8665a4576f6d9dc24ff6d75a82f120d093b0307efd1  # [not osx or not arm64]
-    patches:
+    patches: # [win or linux and aarch64]
       - 01-fix-libffi-msvc.patch     # [win]
       - 02-disable-snapshot.patch    # [linux and aarch64]
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-apple-darwin.zip  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: 65efe137ee28846427ae7b6c5135439744065ad59ccb3c8cd19e69af066e2db0  # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:   # [not osx or not arm64]
   build:   # [not osx or not arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno_src.tar.gz  # [not osx or not arm64]
     sha256: f48758771a456db3fabdf8665a4576f6d9dc24ff6d75a82f120d093b0307efd1  # [not osx or not arm64]
-    patches: # [win or linux and aarch64]
+    patches:  # [win or linux and aarch64]
       - 01-fix-libffi-msvc.patch     # [win]
       - 02-disable-snapshot.patch    # [linux and aarch64]
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-apple-darwin.zip  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,11 +9,7 @@ source:
     sha256: f48758771a456db3fabdf8665a4576f6d9dc24ff6d75a82f120d093b0307efd1  # [not osx or not arm64]
     patches:   # [win]
       - 01-fix-libffi-msvc.patch     # [win]
-  - url: https://github.com/rust-lang/cargo/archive/refs/tags/0.75.0.tar.gz  # [linux and aarch64]
-    sha256: d6b9512bca4b4d692a242188bfe83e1b696c44903007b7b48a56b287d01c063b  # [linux and aarch64]
-    folder: cargo-cross  # [linux and aarch64]
-    patches:   # [linux and aarch64]
-      - cargo-cross-build.patch                                               # [linux and aarch64]
+      - 02-disable-snapshot.patch    # [linux and aarch64]
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-apple-darwin.zip  # [osx and arm64]
     sha256: 65efe137ee28846427ae7b6c5135439744065ad59ccb3c8cd19e69af066e2db0  # [osx and arm64]
 

--- a/recipe/series
+++ b/recipe/series
@@ -1,2 +1,3 @@
-# This series applies on Git commit a62c7e036ab6851c0293f407ead635a7331445b7
+# This series applies on Git commit b32ed7516cfdaaff76203ca530796d6a1235568d
 01-fix-libffi-msvc.patch
+02-disable-snapshot.patch


### PR DESCRIPTION
This is yet another attempt at re-enabling linux-aarch64 builds, this time by disabling V8 snapshotting and cross-compiling Deno.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.