### PR TITLE
Unvendor zlib and disable upgrading

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -22,3 +22,5 @@ rust_compiler_version:
 - 1.82.0
 target_platform:
 - linux-64
+zlib:
+- '1'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,3 +24,5 @@ rust_compiler_version:
 - 1.82.0
 target_platform:
 - osx-64
+zlib:
+- '1'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -10,3 +10,5 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
 - osx-arm64
+zlib:
+- '1'

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,3 +14,5 @@ rust_compiler_version:
 - 1.82.0
 target_platform:
 - win-64
+zlib:
+- '1'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,7 +41,7 @@ else
         CARGO=cargo
     fi
     echo "$CARGO build --release $build_args" >&2
-    $CARGO build --release -v $build_args
+    $CARGO build --release --no-default-features $build_args
 
     mkdir -p $PREFIX/bin
     OUTPUT_EXE=$(find target -name deno | tail -n 1)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     sha256: 51280cbbac5c84aee6346737e46667be8919ada2d55e5707704c999be3ef6c41  # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:   # [not osx or not arm64]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This disables Deno's built-in upgrade feature (since Conda should do the upgrades), and turns off zlib-ng vendoring to use Conda's zlib, to make the Unix builds consistent with Windows.