### PR TITLE
Re-enable linux-aarch64 (updated cargo-cross edition)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.17'
+- '2.28'
 cdt_name:
 - conda
 channel_sources:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libprotobuf:
+- 5.28.3
+rust_compiler:
+- rust
+rust_compiler_version:
+- 1.82.0
+target_platform:
+- linux-aarch64
+zlib:
+- '1'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/deno-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,7 @@ azure:
       MINIFORGE_HOME: C:\Miniforge
       SET_PAGEFILE: "True"
 build_platform:
-  # linux_aarch64: linux_64
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'

--- a/recipe/cargo-cross-build.patch
+++ b/recipe/cargo-cross-build.patch
@@ -31,7 +31,7 @@ index 000000000..86a2636c5
 +$1
 diff --git a/src/cargo/core/compiler/cross_build.rs b/src/cargo/core/compiler/cross_build.rs
 new file mode 100644
-index 000000000..122ea26c9
+index 000000000..3949e77cd
 --- /dev/null
 +++ b/src/cargo/core/compiler/cross_build.rs
 @@ -0,0 +1,151 @@
@@ -41,7 +41,7 @@ index 000000000..122ea26c9
 +
 +use std::env;
 +
-+use log::debug;
++use tracing::debug;
 +
 +use crate::core::compiler::compile_kind::CompileKind;
 +use crate::core::manifest::Target;

--- a/recipe/cargo-cross-build.patch
+++ b/recipe/cargo-cross-build.patch
@@ -1,16 +1,17 @@
-Cargo cross-build patch from https://github.com/fm-elpac/cargo-cross-build
+
+
+From: Michael Ekstrand <mdekstrand@drexel.edu>
+
 
 ---
- run_build.sh                                 |    8 +
- src/cargo/core/compiler/cross_build.rs       |  149 ++++++++++++++++++++++++++
- src/cargo/core/compiler/custom_build.rs      |    3 +
- src/cargo/core/compiler/mod.rs               |   11 +-
- src/cargo/core/compiler/unit_dependencies.rs |   22 +++-
- src/cargo/core/manifest.rs                   |    3 +
- src/cargo/core/profiles.rs                   |    5 +
- 7 files changed, 193 insertions(+), 8 deletions(-)
+ run_build.sh                                 |    8 ++++++++
+ src/cargo/core/compiler/custom_build.rs      |    3 +++
+ src/cargo/core/compiler/mod.rs               |    8 +++-----
+ src/cargo/core/compiler/unit_dependencies.rs |   22 ++++++++++++++++++----
+ src/cargo/core/manifest.rs                   |    3 +++
+ src/cargo/core/profiles.rs                   |    5 +++++
+ 6 files changed, 40 insertions(+), 9 deletions(-)
  create mode 100755 run_build.sh
- create mode 100644 src/cargo/core/compiler/cross_build.rs
 
 diff --git a/run_build.sh b/run_build.sh
 new file mode 100755
@@ -26,169 +27,14 @@ index 000000000..86a2636c5
 +
 +# just run the real build script binary
 +$1
-diff --git a/src/cargo/core/compiler/cross_build.rs b/src/cargo/core/compiler/cross_build.rs
-new file mode 100644
-index 000000000..414a390f0
---- /dev/null
-+++ b/src/cargo/core/compiler/cross_build.rs
-@@ -0,0 +1,149 @@
-+//! # cargo-cross-build
-+//!
-+//! <https://github.com/fm-elpac/cargo-cross-build>
-+
-+use std::env;
-+
-+use crate::core::compiler::compile_kind::CompileKind;
-+use crate::core::manifest::Target;
-+use crate::core::manifest::TargetSourcePath;
-+use crate::core::profiles::UnitFor;
-+use crate::core::Package;
-+use cargo_util::ProcessBuilder;
-+
-+/// env var name: a list of crate name
-+///
-+/// eg: `deno_runtime:deno`
-+const BUILD_CRATES: &'static str = "CARGO_CROSS_BUILD_CRATES";
-+
-+/// env var name: command to run instead of the real build script binary
-+///
-+/// eg: `run_build.sh`
-+const BUILD_RUN: &'static str = "CARGO_CROSS_BUILD_RUN";
-+
-+/// env var name: a list of end of `build.rs` path to build for target
-+///
-+/// eg: `deno_runtime-0.118.0/build.rs:deno-1.35.0/build.rs`
-+const BUILD_RS: &'static str = "CARGO_CROSS_BUILD_RS";
-+
-+const SEP: &'static str = ":";
-+
-+/// config data for cargo-cross-build
-+#[derive(Debug)]
-+struct ConfData {
-+    build_crates: Vec<String>,
-+    build_run: Option<String>,
-+    build_rs: Vec<String>,
-+}
-+
-+impl ConfData {
-+    /// read env var value
-+    pub fn new() -> Self {
-+        let mut o = Self {
-+            build_crates: Vec::new(),
-+            build_run: None,
-+            build_rs: Vec::new(),
-+        };
-+
-+        if let Ok(v) = env::var(BUILD_CRATES) {
-+            for i in v.split(SEP) {
-+                o.build_crates.push(i.to_string());
-+            }
-+        }
-+        if let Ok(v) = env::var(BUILD_RUN) {
-+            o.build_run = Some(v);
-+        }
-+        if let Ok(v) = env::var(BUILD_RS) {
-+            for i in v.split(SEP) {
-+                o.build_rs.push(i.to_string());
-+            }
-+        }
-+        o
-+    }
-+
-+    /// check if name in build_crates
-+    pub fn has(&self, name: &str) -> bool {
-+        for i in &self.build_crates {
-+            if i == name {
-+                return true;
-+            }
-+        }
-+        false
-+    }
-+
-+    /// check `build.rs` path match
-+    pub fn check_rs(&self, p: &TargetSourcePath) -> bool {
-+        if let TargetSourcePath::Path(p) = p {
-+            for i in &self.build_rs {
-+                if p.ends_with(i) {
-+                    return true;
-+                }
-+            }
-+        }
-+        false
-+    }
-+
-+    pub fn get_run(&self) -> Option<String> {
-+        self.build_run.clone()
-+    }
-+}
-+
-+/// get `name` of a crate
-+fn get_pkg_name(p: &Package) -> &'static str {
-+    p.name().as_str()
-+}
-+
-+/// replace build script run command
-+pub fn check_cmd(cmd: &mut ProcessBuilder, p: &Package) {
-+    let name = get_pkg_name(p);
-+
-+    let c = ConfData::new();
-+    if c.has(name) {
-+        if let Some(r) = c.get_run() {
-+            let exec = cmd.get_program().clone();
-+
-+            // debug!("cargo-cross-build (check_cmd): {:?}", c);
-+            println!("cargo-cross-build (check_cmd): name = {}", name);
-+            println!("cargo-cross-build (check_cmd): exec = {:?}", exec);
-+            // debug!("args = {:?}", cmd.get_args().collect::<Vec<_>>());
-+            println!("cargo-cross-build (check_cmd): r = {}", r);
-+
-+            cmd.program(r);
-+            cmd.arg(exec);
-+        }
-+    }
-+}
-+
-+/// set `for_host` for build script Target
-+pub fn check_target(target: &mut Target) {
-+    // target.name() == `build-script-build`
-+    // target.crate_name() == `build_script_build`
-+    let p = target.src_path();
-+
-+    let c = ConfData::new();
-+    if c.check_rs(p) {
-+        // debug!("cargo-cross-build (check_target): {:?}", c);
-+        println!("cargo-cross-build (check_target): for_host(false)  {:?}", p);
-+
-+        // build for target, not host
-+        target.set_for_host(false);
-+    }
-+}
-+
-+/// set `host: false` for build.rs
-+pub fn check_unitfor(u: &mut UnitFor, p: &Package, u2: &UnitFor) -> CompileKind {
-+    let name = get_pkg_name(p);
-+
-+    let c = ConfData::new();
-+    if c.has(name) {
-+        // debug!("cargo-cross-build (check_unitfor): {:?}", c);
-+        println!("cargo-cross-build (check_unitfor): name = {}", name);
-+
-+        u.set_for_host(false);
-+        // not for host
-+        return u2.root_compile_kind();
-+    }
-+
-+    // default value for build script
-+    CompileKind::Host
-+}
 diff --git a/src/cargo/core/compiler/custom_build.rs b/src/cargo/core/compiler/custom_build.rs
-index 3eeeaa0ee..c9f50585c 100644
+index 95126f1f2..cc1b24781 100644
 --- a/src/cargo/core/compiler/custom_build.rs
 +++ b/src/cargo/core/compiler/custom_build.rs
-@@ -275,6 +275,9 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
+@@ -292,6 +292,9 @@ fn build_work(build_runner: &mut BuildRunner<'_, '_>, unit: &Unit) -> CargoResul
      // carried over.
      let to_exec = to_exec.into_os_string();
-     let mut cmd = cx.compilation.host_process(to_exec, &unit.pkg)?;
+     let mut cmd = build_runner.compilation.host_process(to_exec, &unit.pkg)?;
 +    // cargo-cross-build
 +    super::cross_build::check_cmd(&mut cmd, &unit.pkg);
 +
@@ -196,7 +42,7 @@ index 3eeeaa0ee..c9f50585c 100644
      cmd.env("OUT_DIR", &script_out_dir)
          .env("CARGO_MANIFEST_DIR", unit.pkg.root())
 diff --git a/src/cargo/core/compiler/mod.rs b/src/cargo/core/compiler/mod.rs
-index b0f15bd61..bae1027ca 100644
+index 406280c6d..d5db83fd4 100644
 --- a/src/cargo/core/compiler/mod.rs
 +++ b/src/cargo/core/compiler/mod.rs
 @@ -54,6 +54,9 @@ mod unit;
@@ -206,29 +52,26 @@ index b0f15bd61..bae1027ca 100644
 +// cargo-cross-build
 +pub mod cross_build;
 +
+ use std::borrow::Cow;
  use std::collections::{HashMap, HashSet};
  use std::env;
- use std::ffi::{OsStr, OsString};
-@@ -926,10 +929,10 @@ fn add_error_format_and_color(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder) {
+@@ -993,11 +996,6 @@ fn add_error_format_and_color(build_runner: &BuildRunner<'_, '_>, cmd: &mut Proc
+         _ => {}
      }
      cmd.arg(json);
- 
--    let config = cx.bcx.config;
--    if let Some(width) = config.shell().err_width().diagnostic_terminal_width() {
+-
+-    let gctx = build_runner.bcx.gctx;
+-    if let Some(width) = gctx.shell().err_width().diagnostic_terminal_width() {
 -        cmd.arg(format!("--diagnostic-width={width}"));
 -    }
-+    // let config = cx.bcx.config;
-+    // if let Some(width) = config.shell().err_width().diagnostic_terminal_width() {
-+    //     cmd.arg(format!("--diagnostic-width={width}"));
-+    // }
  }
  
  /// Adds essential rustc flags and environment variables to the command to execute.
 diff --git a/src/cargo/core/compiler/unit_dependencies.rs b/src/cargo/core/compiler/unit_dependencies.rs
-index 7116ba207..5ea8f4682 100644
+index c42be2dd8..cb76ce7d7 100644
 --- a/src/cargo/core/compiler/unit_dependencies.rs
 +++ b/src/cargo/core/compiler/unit_dependencies.rs
-@@ -468,7 +468,13 @@ fn compute_deps_custom_build(
+@@ -465,7 +465,13 @@ fn compute_deps_custom_build(
      // All dependencies of this unit should use profiles for custom builds.
      // If this is a build script of a proc macro, make sure it uses host
      // features.
@@ -243,7 +86,7 @@ index 7116ba207..5ea8f4682 100644
      // When not overridden, then the dependencies to run a build script are:
      //
      // 1. Compiling the build script itself.
-@@ -485,7 +491,8 @@ fn compute_deps_custom_build(
+@@ -482,7 +488,8 @@ fn compute_deps_custom_build(
          &unit.target,
          script_unit_for,
          // Build scripts always compiled for the host.
@@ -253,7 +96,7 @@ index 7116ba207..5ea8f4682 100644
          CompileMode::Build,
          IS_NO_ARTIFACT_DEP,
      )?;
-@@ -523,7 +530,8 @@ fn compute_deps_custom_build(
+@@ -520,7 +527,8 @@ fn compute_deps_custom_build(
                      resolved_artifact_compile_kind,
                  ),
                  state,
@@ -279,10 +122,10 @@ index 7116ba207..5ea8f4682 100644
                  state,
                  unit,
 diff --git a/src/cargo/core/manifest.rs b/src/cargo/core/manifest.rs
-index 7886abec3..55c2a8668 100644
+index d63dbd61d..0f7b736d7 100644
 --- a/src/cargo/core/manifest.rs
 +++ b/src/cargo/core/manifest.rs
-@@ -719,6 +719,9 @@ impl Target {
+@@ -807,6 +807,9 @@ impl Target {
              .set_benched(false)
              .set_tested(false)
              .set_doc_scrape_examples(RustdocScrapeExamples::Disabled);
@@ -293,10 +136,10 @@ index 7886abec3..55c2a8668 100644
      }
  
 diff --git a/src/cargo/core/profiles.rs b/src/cargo/core/profiles.rs
-index 1ad9ed5f7..4818e9050 100644
+index b7e8fe9c9..8faf3a08b 100644
 --- a/src/cargo/core/profiles.rs
 +++ b/src/cargo/core/profiles.rs
-@@ -1127,6 +1127,11 @@ impl UnitFor {
+@@ -1218,6 +1218,11 @@ impl UnitFor {
          self.host_features
      }
  

--- a/recipe/cargo-cross-build.patch
+++ b/recipe/cargo-cross-build.patch
@@ -4,14 +4,16 @@ From: Michael Ekstrand <mdekstrand@drexel.edu>
 
 
 ---
- run_build.sh                                 |    8 ++++++++
- src/cargo/core/compiler/custom_build.rs      |    3 +++
- src/cargo/core/compiler/mod.rs               |    8 +++-----
- src/cargo/core/compiler/unit_dependencies.rs |   22 ++++++++++++++++++----
- src/cargo/core/manifest.rs                   |    3 +++
- src/cargo/core/profiles.rs                   |    5 +++++
- 6 files changed, 40 insertions(+), 9 deletions(-)
+ run_build.sh                                 |    8 +
+ src/cargo/core/compiler/cross_build.rs       |  151 ++++++++++++++++++++++++++
+ src/cargo/core/compiler/custom_build.rs      |    3 +
+ src/cargo/core/compiler/mod.rs               |    8 +
+ src/cargo/core/compiler/unit_dependencies.rs |   22 +++-
+ src/cargo/core/manifest.rs                   |    3 +
+ src/cargo/core/profiles.rs                   |    5 +
+ 7 files changed, 191 insertions(+), 9 deletions(-)
  create mode 100755 run_build.sh
+ create mode 100644 src/cargo/core/compiler/cross_build.rs
 
 diff --git a/run_build.sh b/run_build.sh
 new file mode 100755
@@ -27,6 +29,163 @@ index 000000000..86a2636c5
 +
 +# just run the real build script binary
 +$1
+diff --git a/src/cargo/core/compiler/cross_build.rs b/src/cargo/core/compiler/cross_build.rs
+new file mode 100644
+index 000000000..122ea26c9
+--- /dev/null
++++ b/src/cargo/core/compiler/cross_build.rs
+@@ -0,0 +1,151 @@
++//! # cargo-cross-build
++//!
++//! <https://github.com/fm-elpac/cargo-cross-build>
++
++use std::env;
++
++use log::debug;
++
++use crate::core::compiler::compile_kind::CompileKind;
++use crate::core::manifest::Target;
++use crate::core::manifest::TargetSourcePath;
++use crate::core::profiles::UnitFor;
++use crate::core::Package;
++use cargo_util::ProcessBuilder;
++
++/// env var name: a list of crate name
++///
++/// eg: `deno_runtime:deno`
++const BUILD_CRATES: &'static str = "CARGO_CROSS_BUILD_CRATES";
++
++/// env var name: command to run instead of the real build script binary
++///
++/// eg: `run_build.sh`
++const BUILD_RUN: &'static str = "CARGO_CROSS_BUILD_RUN";
++
++/// env var name: a list of end of `build.rs` path to build for target
++///
++/// eg: `deno_runtime-0.118.0/build.rs:deno-1.35.0/build.rs`
++const BUILD_RS: &'static str = "CARGO_CROSS_BUILD_RS";
++
++const SEP: &'static str = ":";
++
++/// config data for cargo-cross-build
++#[derive(Debug)]
++struct ConfData {
++    build_crates: Vec<String>,
++    build_run: Option<String>,
++    build_rs: Vec<String>,
++}
++
++impl ConfData {
++    /// read env var value
++    pub fn new() -> Self {
++        let mut o = Self {
++            build_crates: Vec::new(),
++            build_run: None,
++            build_rs: Vec::new(),
++        };
++
++        if let Ok(v) = env::var(BUILD_CRATES) {
++            for i in v.split(SEP) {
++                o.build_crates.push(i.to_string());
++            }
++        }
++        if let Ok(v) = env::var(BUILD_RUN) {
++            o.build_run = Some(v);
++        }
++        if let Ok(v) = env::var(BUILD_RS) {
++            for i in v.split(SEP) {
++                o.build_rs.push(i.to_string());
++            }
++        }
++        o
++    }
++
++    /// check if name in build_crates
++    pub fn has(&self, name: &str) -> bool {
++        for i in &self.build_crates {
++            if i == name {
++                return true;
++            }
++        }
++        false
++    }
++
++    /// check `build.rs` path match
++    pub fn check_rs(&self, p: &TargetSourcePath) -> bool {
++        if let TargetSourcePath::Path(p) = p {
++            for i in &self.build_rs {
++                if p.ends_with(i) {
++                    return true;
++                }
++            }
++        }
++        false
++    }
++
++    pub fn get_run(&self) -> Option<String> {
++        self.build_run.clone()
++    }
++}
++
++/// get `name` of a crate
++fn get_pkg_name(p: &Package) -> &'static str {
++    p.name().as_str()
++}
++
++/// replace build script run command
++pub fn check_cmd(cmd: &mut ProcessBuilder, p: &Package) {
++    let name = get_pkg_name(p);
++
++    let c = ConfData::new();
++    if c.has(name) {
++        if let Some(r) = c.get_run() {
++            let exec = cmd.get_program().clone();
++
++            debug!("cargo-cross-build (check_cmd): {:?}", c);
++            println!("cargo-cross-build (check_cmd): name = {}", name);
++            println!("cargo-cross-build (check_cmd): exec = {:?}", exec);
++            debug!("args = {:?}", cmd.get_args().collect::<Vec<_>>());
++            println!("cargo-cross-build (check_cmd): r = {}", r);
++
++            cmd.program(r);
++            cmd.arg(exec);
++        }
++    }
++}
++
++/// set `for_host` for build script Target
++pub fn check_target(target: &mut Target) {
++    // target.name() == `build-script-build`
++    // target.crate_name() == `build_script_build`
++    let p = target.src_path();
++
++    let c = ConfData::new();
++    if c.check_rs(p) {
++        debug!("cargo-cross-build (check_target): {:?}", c);
++        println!("cargo-cross-build (check_target): for_host(false)  {:?}", p);
++
++        // build for target, not host
++        target.set_for_host(false);
++    }
++}
++
++/// set `host: false` for build.rs
++pub fn check_unitfor(u: &mut UnitFor, p: &Package, u2: &UnitFor) -> CompileKind {
++    let name = get_pkg_name(p);
++
++    let c = ConfData::new();
++    if c.has(name) {
++        debug!("cargo-cross-build (check_unitfor): {:?}", c);
++        println!("cargo-cross-build (check_unitfor): name = {}", name);
++
++        u.set_for_host(false);
++        // not for host
++        return u2.root_compile_kind();
++    }
++
++    // default value for build script
++    CompileKind::Host
++}
 diff --git a/src/cargo/core/compiler/custom_build.rs b/src/cargo/core/compiler/custom_build.rs
 index 95126f1f2..cc1b24781 100644
 --- a/src/cargo/core/compiler/custom_build.rs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,8 @@ source:
     sha256: b65f55840d7bfa3fb16ae65ca45cdc33dc38427dca625c80411c07a466f5cd2e  # [not osx or not arm64]
     patches:   # [win]
       - 01-fix-libffi-msvc.patch     # [win]
-  - url: https://github.com/rust-lang/cargo/archive/refs/tags/0.75.0.tar.gz  # [linux and aarch64]
-    sha256: d6b9512bca4b4d692a242188bfe83e1b696c44903007b7b48a56b287d01c063b  # [linux and aarch64]
+  - url: https://github.com/rust-lang/cargo/archive/refs/tags/0.85.0.tar.gz  # [linux and aarch64]
+    sha256: 5e708627470d41be5d615b0f064d5cbe40509cab62e751a2876936fb53ca0bcd  # [linux and aarch64]
     folder: cargo-cross  # [linux and aarch64]
     patches:   # [linux and aarch64]
       - cargo-cross-build.patch                                               # [linux and aarch64]
@@ -18,7 +18,7 @@ source:
     sha256: a0aff1d56948f030d0596085f2db0374670331c848bb642b25e21fab986b6c9f  # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:   # [not osx or not arm64]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This is my third (fourth?) attempt to get the `linux-aarch64` builds working again. This time I updated the `cargo-cross-build` patch to work with a more modern Cargo instead of trying other shenanigans.

Dear upstreams: please don't make builds such a brittle pile…