### PR TITLE
Publish for linux-aarch64 with binary repacking (again)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,26 @@
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.28'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libprotobuf:
+- 5.28.3
+rust_compiler:
+- rust
+rust_compiler_version:
+- 1.82.0
+target_platform:
+- linux-aarch64
+zlib:
+- '1'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/deno-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=14856&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,7 @@ azure:
       MINIFORGE_HOME: C:\Miniforge
       SET_PAGEFILE: "True"
 build_platform:
-  # linux_aarch64: linux_64
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,8 +3,8 @@
 set -e
 
 mkdir -p $PREFIX/bin
-if [ "$SUBDIR" = "osx-arm64" ]; then
-    mv deno $PREFIX/bin
+if [ -d release-build ]; then
+    cp release-build/deno $PREFIX/bin
 else
 
     cargo bundle-licenses --format yaml --output DENO_THIRDPARTY_LICENSES.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,10 +32,6 @@ requirements:
     - cmake  # [unix and not arm64]
     # libprotobuf is on build, not host, since we only need protoc
     - libprotobuf  # [not osx or not arm64]
-    # on linux cross-builds, we need additional build deps for patched cargo
-    - zlib         # [linux and aarch64]
-    - libclang     # [linux and x86_64]
-    - llvmdev      # [linux and x86_64]
   # cross-builds also need host libgcc to run the cross-built files
   host:
     - libgcc    # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,16 +9,15 @@ source:
     sha256: 4dd4cf474b0cf76b3d3989ca855432da0c41667a412e51f8223d1ff806c44754  # [not osx or not arm64]
     patches:   # [win]
       - 01-fix-libffi-msvc.patch     # [win]
-  - url: https://github.com/rust-lang/cargo/archive/refs/tags/0.75.0.tar.gz  # [linux and aarch64]
-    sha256: d6b9512bca4b4d692a242188bfe83e1b696c44903007b7b48a56b287d01c063b  # [linux and aarch64]
-    folder: cargo-cross  # [linux and aarch64]
-    patches:   # [linux and aarch64]
-      - cargo-cross-build.patch                                               # [linux and aarch64]
+  - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-unknown-linux-gnu.zip  # [linux and aarch64]
+    sha256: 2de9af6894d7e9eaeb5b140c341ee8a8670f27c673f381ae27e8edc8e5dd45b7  # [linux and aarch64]
+    folder: release-build # [linux and aarch64]
   - url: https://github.com/denoland/deno/releases/download/v{{ version }}/deno-aarch64-apple-darwin.zip  # [osx and arm64]
     sha256: 2e7029ccc30e7500963d9e7519a3e20ff29941ffe730c6901b61cf58421e6f4b  # [osx and arm64]
+    folder: release-build # [osx and arm64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:   # [not osx or not arm64]


### PR DESCRIPTION
This is another attempt at a binary repack for `linux-aarch64`.

Checklist:
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
