### PR TITLE
Update to Deno 2.5.7

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,12 @@ jobs:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15-arm64
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,7 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: C:\\bld\\

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,11 +23,13 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-24.04-arm']
@@ -104,7 +106,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "deno-feedstock"
-version = "3.60.0"  # conda-smithy version used to generate this file
+version = "3.61.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/deno-feedstock"
 authors = ["@conda-forge/deno"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "2.4.5"
+  version: "2.5.6"
 
 package:
   name: deno
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/denoland/deno/releases/download/v${{ version }}/deno_src.tar.gz
-  sha256: a6bba626d08813c114bfcc862e69fd7202eecda97df9f349abf6cc4e38fe4e40
+  sha256: 62d3e8f87aed734cdce27660ebfed1c31b6b279f21f36070cdc64e828ae3bfb0
 
 build:
   number: 0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "2.5.6"
+  version: "2.5.7"
 
 package:
   name: deno
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/denoland/deno/releases/download/v${{ version }}/deno_src.tar.gz
-  sha256: 62d3e8f87aed734cdce27660ebfed1c31b6b279f21f36070cdc64e828ae3bfb0
+  sha256: 543d0a16e7ae52ca9f0a6edf4782ffcf1b5bb8e0077ac39845ddf0bd6a615875
 
 build:
   number: 0


### PR DESCRIPTION
Bumps Deno from 2.4.5 to 2.5.7, using the same source-build pattern that landed in #196.

Originally targeted 2.5.6, but Deno 2.5.6 fails to compile on conda-forge's default rust (1.94.0) with [`E0716`](https://doc.rust-lang.org/error_codes/E0716.html) in `cli/tools/pm/audit.rs:492` — Deno itself tests with 1.90.0 and missed the borrow-checker violation. Fixed upstream in 2.5.7 ([denoland/deno@v2.5.6...v2.5.7 `cli/tools/pm/audit.rs`](https://github.com/denoland/deno/compare/v2.5.6...v2.5.7#diff-cli/tools/pm/audit.rs)), so no `rust_compiler_version` pin is needed here.

Supersedes the autotick-bot PRs #187, #188, #189, #190 (2.5.1 through 2.5.4) — they will auto-close on merge.

First of a three-PR series bumping one minor at a time so each publishes a distinct conda-forge release: 2.5.7 → 2.6.10 → 2.7.12.