### PR TITLE
Update to Deno 2.6.10

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "2.5.7"
+  version: "2.6.10"
 
 package:
   name: deno
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/denoland/deno/releases/download/v${{ version }}/deno_src.tar.gz
-  sha256: 543d0a16e7ae52ca9f0a6edf4782ffcf1b5bb8e0077ac39845ddf0bd6a615875
+  sha256: 9d36d89e11b61626d732d71fd5a2b83afba06d02373f1fa8daffff3a0addf936
 
 build:
   number: 0


### PR DESCRIPTION
Bumps Deno from 2.5.7 to 2.6.10, same minimal source-build pattern as #197 and #196.

Rust 1.92.0 is required per [`rust-toolchain.toml@v2.6.10`](https://github.com/denoland/deno/blob/v2.6.10/rust-toolchain.toml) — conda-forge's default `rust` is already at 1.94.0, so no `rust_compiler_version` pin is needed.

Supersedes #191 (earlier 2.6.10 attempt with Rust 1.93.1 pin and broader recipe rework). That PR stalled at Windows + Linux build failures; the minimal version+sha256 pattern that landed in #196 and #197 should avoid them.

Second of a three-PR series: 2.5.7 → 2.6.10 → 2.7.12.