### PR TITLE
Update to Deno 2.7.12

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "2.6.10"
+  version: "2.7.12"
 
 package:
   name: deno
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/denoland/deno/releases/download/v${{ version }}/deno_src.tar.gz
-  sha256: 9d36d89e11b61626d732d71fd5a2b83afba06d02373f1fa8daffff3a0addf936
+  sha256: be57e4f92a9b0d3aca4700631b6d6249c9db391e88bf09f0b8c7989d76151e8a
 
 build:
   number: 0


### PR DESCRIPTION
Bumps Deno from 2.6.10 to 2.7.12, same minimal source-build pattern as #198, #197, #196.

Rust 1.92.0 is required per [`rust-toolchain.toml@v2.7.12`](https://github.com/denoland/deno/blob/v2.7.12/rust-toolchain.toml) — conda-forge's default `rust` is already at 1.94.0, so no `rust_compiler_version` pin is needed.

Third of the three-PR series: 2.5.7 → 2.6.10 → 2.7.12.